### PR TITLE
Add past events

### DIFF
--- a/_sections/performances.md
+++ b/_sections/performances.md
@@ -3,12 +3,28 @@ title: Performances
 backgroundUrl: /assets/img/drum-background-03.jpg
 ---
 
+<div class="list-group" id="past-event-list"></div>
+
+#### Upcoming Performances
+
 <div class="list-group" id="event-list"></div>
 
 <script type="text/javascript">
   $(function() {
+    $('#past-event-list').gCalReader({
+        calendarId:'ofhs64hf3fh1upgmchqmqi0op4@group.calendar.google.com',
+        apiKey:'AIzaSyC0vgU_TedzMkjC13YrqOs9_u1VtbsoDyE',
+        futureEventsOnly: false,
+        pastEvents: true,
+        sortDescending: false
+    });
+  });
+</script>
+
+<script type="text/javascript">
+  $(function() {
     $('#event-list').gCalReader({
-        calendarId:'ofhs64hf3fh1upgmchqmqi0op4@group.calendar.google.com', 
+        calendarId:'ofhs64hf3fh1upgmchqmqi0op4@group.calendar.google.com',
         apiKey:'AIzaSyC0vgU_TedzMkjC13YrqOs9_u1VtbsoDyE',
         futureEventsOnly: true,
         sortDescending: false

--- a/assets/js/jquery.google.calendar.js
+++ b/assets/js/jquery.google.calendar.js
@@ -10,16 +10,24 @@
         errorMsg: 'No events in calendar',
         maxEvents: 50,
         futureEventsOnly: true,
+        pastEvents: false,
         sortDescending: true
       },
       options);
 
     var s = '';
+    var now = new Date();
     var feedUrl = 'https://www.googleapis.com/calendar/v3/calendars/' +
       encodeURIComponent(defaults.calendarId.trim()) +'/events?key=' + defaults.apiKey +
       '&orderBy=startTime&singleEvents=true';
       if(defaults.futureEventsOnly) {
-        feedUrl+='&timeMin='+ new Date().toISOString();
+        feedUrl+='&timeMin='+ now.toISOString();
+      }
+      if(defaults.pastEvents) {
+        feedUrl+='&timeMax='+ now.toISOString();
+        timeMin = new Date();
+        timeMin.setMonth(timeMin.getMonth()-6);
+        feedUrl+='&timeMin='+ timeMin.toISOString();
       }
 
     $.ajax({


### PR DESCRIPTION
Fix #2

This approach seamlessly splits the past and upcoming performances into two tables:
<img width="755" alt="Screen Shot 2022-04-21 at 8 08 53 AM" src="https://user-images.githubusercontent.com/18717376/164489219-e54e32dd-b3f2-441b-aac9-05864d075701.png">


This screenshot visualizes the concept zoomed out to show the principle:
<img width="200" alt="Screen Shot 2022-04-21 at 8 08 41 AM" src="https://user-images.githubusercontent.com/18717376/164489571-c0ded265-0353-4cc8-814b-384aafefc11d.png">

@kenzie32l do you like that approach?

